### PR TITLE
link with libtinfo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CXX=clang++
 CXXFLAGS=-Wall -std=c++17
-LIBS=-lncurses
+LIBS=-lncurses -ltinfo
 SRC=main.cpp snake.cpp game.cpp
 
 all:


### PR DESCRIPTION
this fixes error
```
undefined reference to symbol 'cbreak'
/lib64/libtinfo.so.6: error adding symbols: DSO missing from command line
```